### PR TITLE
feat: create ticktick labelled folder models

### DIFF
--- a/lightdash/charts/data-freshness.yml
+++ b/lightdash/charts/data-freshness.yml
@@ -28,7 +28,7 @@ metricQuery:
     - name: updated_time_minute_max_of_updated_time_minute
       label: Max of Updated time minute
       description: "Max of Updated time minute on the table Fct tasks "
-      uuid: 6044d380-ac71-494f-bff0-6d024a3eb5e9
+      uuid: 05e9c86d-f87d-4906-a16d-a7cedce9e911
       sql: DATE_TRUNC(${TABLE}.updated_time, MINUTE)
       table: fct_tasks
       type: max
@@ -52,4 +52,4 @@ tableConfig:
     - fct_tasks_updated_time_minute
 spaceSlug: shared
 version: 1
-downloadedAt: "2025-10-04T09:22:29.235Z"
+downloadedAt: "2025-10-05T14:29:18.917Z"

--- a/lightdash/charts/next-load-time.yml
+++ b/lightdash/charts/next-load-time.yml
@@ -41,4 +41,4 @@ tableConfig:
     - fct_tasks_title
 spaceSlug: shared
 version: 1
-downloadedAt: "2025-10-04T09:22:29.234Z"
+downloadedAt: "2025-10-05T14:29:18.917Z"

--- a/lightdash/charts/tasks-lookahead.yml
+++ b/lightdash/charts/tasks-lookahead.yml
@@ -167,4 +167,4 @@ tableConfig:
       agg_daily_task_schedule_with_weekly_avg_weekly_average_tasks_per_project_metric
 spaceSlug: shared
 version: 1
-downloadedAt: "2025-10-04T09:22:29.234Z"
+downloadedAt: "2025-10-05T14:29:18.917Z"

--- a/lightdash/charts/what-did-you-do.yml
+++ b/lightdash/charts/what-did-you-do.yml
@@ -1,13 +1,14 @@
 name: what did you do?
 description: ""
 tableName: fct_tasks
-updatedAt: "2025-10-04T09:20:08.344Z"
+updatedAt: "2025-10-05T14:28:47.126Z"
 metricQuery:
   exploreName: fct_tasks
   dimensions:
     - fct_tasks_completed_time_day
     - fct_tasks_completed_time_day_of_week_name
     - fct_tasks_gtd_work_type
+    - dim_folders_folder_name
     - dim_projects_project_name
     - fct_tasks_title
     - fct_tasks_task_id
@@ -79,6 +80,7 @@ tableConfig:
     - fct_tasks_completed_time_day
     - fct_tasks_completed_time_day_of_week_name
     - fct_tasks_gtd_work_type
+    - dim_folders_folder_name
     - dim_projects_project_name
     - fct_tasks_title
     - fct_tasks_task_id
@@ -86,4 +88,4 @@ tableConfig:
     - fct_tasks_updated_time_raw
 spaceSlug: shared
 version: 1
-downloadedAt: "2025-10-04T09:22:29.235Z"
+downloadedAt: "2025-10-05T14:29:18.917Z"

--- a/lightdash/dashboards/gtd-dash-v1-0.yml
+++ b/lightdash/dashboards/gtd-dash-v1-0.yml
@@ -58,4 +58,4 @@ tabs: []
 slug: gtd-dash-v1-0
 spaceSlug: shared
 version: 1
-downloadedAt: "2025-10-04T09:22:29.616Z"
+downloadedAt: "2025-10-05T14:29:20.937Z"

--- a/models/marts/dim_folders.sql
+++ b/models/marts/dim_folders.sql
@@ -1,0 +1,10 @@
+with source as (
+    select * from {{ref('stg__ticktick__project_folder')}}
+),
+
+final as (
+    select *  from source
+)
+
+select * from source
+

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -206,10 +206,14 @@ models:
             type: left
             sql_on: ${fct_tasks.task_id} = ${fct_task_tags_bridge.task_id}
             relationship: one-to-many
+            hidden: true
           - join: dim_tags
             type: left
             sql_on: ${fct_task_tags_bridge.tag_id} = ${dim_tags.tag_id}
             relationship: many-to-one
+          - join: dim_folders
+            type: left
+            sql_on: ${dim_folders.folder_id} = ${dim_projects.group_id}
         metrics:
           total_task_instances:
             label: Total Tasks
@@ -478,9 +482,6 @@ models:
   - name: fct_task_tags_bridge
     description: >-
       Bridge table connecting tasks to their tags. The grain is one row per task-tag relationship.
-    config:
-      meta:
-        hidden: true
     columns:
       - name: tag_id
         description: Surrogate key for the tag.
@@ -497,6 +498,18 @@ models:
           - relationships:
               to: ref('fct_tasks')
               field: task_id
+        config:
+          meta: {}
+          tags: []
+  - name: dim_folders
+    columns:
+      - name: folder_id
+        description: unique identifer of the folder
+        config:
+          meta: {}
+          tags: []
+      - name: folder_name
+        description: The folder name. Inferred from dummy project manually created by users
         config:
           meta: {}
           tags: []

--- a/models/staging/ticktick/stg__ticktick__project_folder.sql
+++ b/models/staging/ticktick/stg__ticktick__project_folder.sql
@@ -1,0 +1,23 @@
+with source as (
+    select * from {{ ref('stg__ticktick__projects') }}
+),
+
+extract_labels as (
+    select 
+    project_name,
+    group_id,
+    regexp_extract(project_name, r"folder_map - '(.*)'") as folder_name
+
+    from source
+    where project_name like 'folder_map - %'
+),
+
+final as (
+    select 
+    distinct
+    group_id as folder_id,
+    folder_name
+    from extract_labels
+)
+
+select * from final

--- a/models/staging/ticktick/ticktick.yml
+++ b/models/staging/ticktick/ticktick.yml
@@ -205,3 +205,21 @@ models:
         config:
           meta: {}
           tags: []
+  - name: stg__ticktick__project_folder
+    description: |
+      - Folders where the projects belong to.
+      - Inferred from dummy projects created from user with this specific naming convension : `folder_map - '<the_name>'`
+      - Has a failsafe in that if user didn't create dummy label projet then we just don't load any data.
+    columns:
+      - name: folder_id
+        description: unique identifer of the folder
+        data_tests:
+          - unique
+        config:
+          meta: {}
+          tags: []
+      - name: folder_name
+        description: The folder name. Inferred from dummy project manually created by users
+        config:
+          meta: {}
+          tags: []


### PR DESCRIPTION

### Description

**Context & Problem:**

This PR introduces a new `dim_folders` dimension to the dbt project. The TickTick API does not provide folder information directly, which is a critical missing piece for high-level GTD analysis (e.g., grouping projects by "Area of Responsibility").

Previously, we considered static solutions like `dbt seeds` or external Google Sheets, but these approaches coupled the dbt project with user-specific configuration, making it difficult to share and distribute.

**Solution:**

This implementation introduces a dynamic and distributable method for mapping projects to folders. The core idea is to derive the mapping from the source data itself, guided by a user-configured convention.

1.  **User-Driven Configuration:** Users can now define their folder structure by creating a "dummy" project within each TickTick folder. These projects must follow a specific naming convention: `folder_map - '<folder_name>'`.
2.  **Dynamic Extraction:** A new staging model, `stg__ticktick__project_folder`, uses a regular expression to find these dummy projects and extract the `folder_name` and its corresponding `group_id` (folder ID).
3.  **New Dimension:** The `dim_folders` model provides a clean, de-duplicated mapping of `folder_id` to `folder_name`.
4.  **Integration:** The `folder_name` is joined into the `fct_tasks` model, making it available for analysis across the entire project.
5.  **Visualization:** The new dimension has been added to the "what did you do?" chart in Lightdash, allowing for immediate analysis of tasks grouped by folder.

**Key Benefits:**

*   **Decoupled & Distributable:** The dbt project contains no hardcoded, user-specific folder information. It can be safely shared and run by other users.
*   **Graceful Fallback:** If a user does not configure the dummy projects, the folder dimension will simply be empty, but no models will fail.
*   **User-Centric:** The source of truth for the folder mapping now lives where it belongs—with the user, in their own TickTick application.
